### PR TITLE
Update fitur daftar biar gk ush pake handler.register = true + auto read chat

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -76,6 +76,7 @@ module.exports = {
       if (m.isBaileys) return
       m.exp += Math.ceil(Math.random() * 10)
 
+      await conn.chatRead(m.chat)
       let usedPrefix
       let _user = global.DATABASE.data && global.DATABASE.data.users && global.DATABASE.data.users[m.sender]
 
@@ -172,7 +173,7 @@ module.exports = {
             fail('private', m, this)
             continue
           }
-          if (plugin.register == true && _user.registered == false) { // Butuh daftar?
+          if (plugin.register == undefined && _user.registered == false) { // Butuh daftar?
             fail('unreg', m, this)
             continue
           }


### PR DESCRIPTION
Jadi klo difile plugins gk ada handler.register itu otomatis klo org mau pake fitur itu harus daftar,, jdi gk ush repot2 nulis handler.register = true di setiap file plugins,, kan cape :v + add auto baca pesan yg masuk biar gk cape2 ngebuka pesan wa