### PR TITLE
Update webp2mp4.js

### DIFF
--- a/lib/webp2mp4.js
+++ b/lib/webp2mp4.js
@@ -7,7 +7,7 @@ async function webp2mp4(source) {
   let isUrl = typeof source === 'string' && /https?:\/\//.test(source)
   form.append('new-image-url', isUrl ? source : '')
   form.append('new-image', isUrl ? '' : source, 'image.webp')
-  let res = await fetch('https://s6.ezgif.com/webp-to-mp4', {
+  let res = await fetch('https://ezgif.com/webp-to-mp4', {
     method: 'POST',
     body: form
   })
@@ -33,7 +33,7 @@ async function webp2png(source) {
   let isUrl = typeof source === 'string' && /https?:\/\//.test(source)
   form.append('new-image-url', isUrl ? source : '')
   form.append('new-image', isUrl ? '' : source, 'image.webp')
-  let res = await fetch('https://s6.ezgif.com/webp-to-png', {
+  let res = await fetch('https://ezgif.com/webp-to-png', {
     method: 'POST',
     body: form
   })


### PR DESCRIPTION
This will work the same, but let the load balancer on ezgif automatically select a server for you, instead of putting all the bot traffic on one. It will also avoid issues if this one server is down.